### PR TITLE
Add mochiweb dependency of webzmachine to the .app file

### DIFF
--- a/src/webzmachine.app.src
+++ b/src/webzmachine.app.src
@@ -7,4 +7,4 @@
   {registered, []},
   {mod, {webmachine_app, []}},
   {env, [{node_id, 1}]},
-  {applications, [kernel, stdlib, crypto]}]}.
+  {applications, [kernel, stdlib, crypto, mochiweb]}]}.


### PR DESCRIPTION
Mochiweb is a dependency of webzmachine which should be started before the webzmachine application. Add it to the .app file so that in a release applications are started in a correct order.
