### PR TITLE
Update lager

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -148,8 +148,8 @@ do_log(LogData) ->
         {ok, LoggerModule} -> spawn(LoggerModule, log_access, [LogData]);
         _ -> nop
     end,
-    case application:get_env(webzmachine, enable_perf_logger) of
-        {ok, true} ->
+    case application:get_env(webzmachine, perf_log_dir) of
+        {ok, _} ->
 	       spawn(webmachine_perf_logger, log, [LogData]);
 	   _ ->
 	       ignore

--- a/src/webmachine_sup.erl
+++ b/src/webmachine_sup.erl
@@ -21,8 +21,7 @@
 -behaviour(supervisor).
 
 %% External exports
--export([start_link/0, upgrade/0, start_logger/1]).
--export([start_perf_logger/1]).
+-export([start_link/0, upgrade/0, start_logger/0]).
 
 %% supervisor callbacks
 -export([init/1]).
@@ -34,23 +33,32 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-start_logger(BaseDir) ->
-    case application:get_env(webzmachine, webmachine_logger_module) of
-        {ok, LoggerModule} ->
-            ChildSpec = 
-                {webmachine_logger,
-                 {LoggerModule, start_link, [BaseDir]},
-                 permanent, 5000, worker, dynamic},
-            supervisor:start_child(?MODULE, ChildSpec);
-        _ -> nop
-    end.
+start_logger() ->
+    start_logger(application:get_env(webzmachine, log_dir)),
+    start_perf_logger(application:get_env(webzmachine, perf_log_dir)).
 
-start_perf_logger(BaseDir) ->
-    ChildSpec = 
-        {webmachine_perf_logger,
-         {webmachine_perf_logger, start_link, [BaseDir]},
-         permanent, 5000, worker, [webmachine_perf_logger]},
+start_logger({ok, LogDir}) ->
+    Logger = application:get_env(webzmachine, webmachine_logger_module),
+    start_logger(Logger, ensure_dir(LogDir));
+start_logger(_) -> nop.
+
+start_logger({ok, webmachine_logger}, Path) ->
+    start_child(webmachine_logger, Path);
+start_logger({ok, Logger}, Path) ->
+    start_child(webmachine_logger, Path),
+    start_child(Logger, Path);
+start_logger(_, _) -> nop.
+
+start_child(Name, Path) ->
+    ChildSpec = {Name, {Name, start_link, [Path]}, permanent, 5000, worker, dynamic},
     supervisor:start_child(?MODULE, ChildSpec).
+
+start_perf_logger({ok, PerfDir}) ->
+    Path = ensure_dir(PerfDir),
+    ChildSpec = {webmachine_perf_logger, {webmachine_perf_logger, start_link, [Path]},
+                 permanent, 5000, worker, [webmachine_perf_logger]},
+    supervisor:start_child(?MODULE, ChildSpec);
+start_perf_logger(_) -> nop.
 
 %% @spec upgrade() -> ok
 %% @doc Add processes if necessary.
@@ -79,14 +87,15 @@ init([]) ->
     {ok, {{one_for_one, 9, 10}, Processes}}.
 
 init_wmtrace() ->
-    Dir = valid_wmtrace_dir(application:get_env(wmtrace_dir)),
-    ok = filelib:ensure_dir(filename:join(Dir, "test")),		
+    Dir = ensure_dir(default_wmtrace_dir(application:get_env(wmtrace_dir))),
     ets:new(?WMTRACE_CONF_TBL, [set, public, named_table]),
     ets:insert(?WMTRACE_CONF_TBL, {trace_dir, Dir}).
 
-valid_wmtrace_dir(undefined) -> filename:join([get_path(), "priv", "wmtrace"]);
-valid_wmtrace_dir({ok, Dir}) when is_list(Dir) -> Dir.
+default_wmtrace_dir({ok, Dir}) -> Dir;
+default_wmtrace_dir(undefined) -> filename:join("priv", "wmtrace").
 
-get_path() ->
+ensure_dir(Dir) ->
     {ok, CWD} = file:get_cwd(),
-    CWD.
+    Path = filename:join(CWD, Dir),
+    ok = filelib:ensure_dir(filename:join(Path, "dummy")),
+    Path.


### PR DESCRIPTION
Changes that match changes in Zotonic in pull-request from a branch of the same name (update-lager).

Three main changes:
- Switch logging and performance logging on/off by simply enabling/disabling the logging directory option (and allow to use separate folders for the access and performance logs)
- This is probably important: in the old code if z_stats was used as the "webmachine_logger_module", the "webmachine_logger" gen_server was not being started at all. But it is required by z_stats to make the actual logging. I pulled sources from master and verified that in the current code the access logs are not created! How can it work for you? Maybe it's down to a different configuration? Anyways, now with the default configuration "webmachine_logger" is being started IN ADDITION to any custom logger module. It's just a gen_server so it can run with a very small footprint but it will be useful to have it running in case the custom logger module wants to leverage it to do the actual logging (like z_stats).
- And of course another change is reading the log directories from the application configuration, which steams from tidying-up logs in Zotonic (the other pull-request).
